### PR TITLE
Remove additional ‘preview’ typo

### DIFF
--- a/lib/font-viewer-view.coffee
+++ b/lib/font-viewer-view.coffee
@@ -10,7 +10,7 @@ class FontViewerView extends ScrollView
     @div class: 'font-viewer', tabindex: -1, =>
       @style outlet: 'style'
       @div class: 'font-container', outlet: 'container'
-preview
+
   initialize: (@fontViewer) ->
     super
     @emitter = new Emitter


### PR DESCRIPTION
I've tested around partially reverting the [latest change](https://github.com/ericfreese/font-viewer/commit/ba9d51e8c0241d49d628cfcee137036521433691#diff-71354f0f02942ac8e174669128204922L12), and finally found out that `preview` has no longer existed. This PR would fix that.

---

**Note:** I've had another issue regarding a crash on calling `ft.Get_First_Char` in [`font-viewer.coffee`](https://github.com/ericfreese/font-viewer/blob/a978e7dc604474664ba5f1ed95e5d9aeaeeaad59/lib/font-viewer.coffee#L56), probably related to ericfreese/node-freetype2#10, so I haven't fully tested the PR yet. 
