### PR TITLE
Fix problem of previewing font file

### DIFF
--- a/lib/font-viewer-view.coffee
+++ b/lib/font-viewer-view.coffee
@@ -10,7 +10,7 @@ class FontViewerView extends ScrollView
     @div class: 'font-viewer', tabindex: -1, =>
       @style outlet: 'style'
       @div class: 'font-container', outlet: 'container'
-preview
+
   initialize: (@fontViewer) ->
     super
     @emitter = new Emitter

--- a/lib/font-viewer.coffee
+++ b/lib/font-viewer.coffee
@@ -52,7 +52,9 @@ class FontViewer
     fs.readFile @getPath(), (err, buffer) ->
       chars = []
       gindex = {}
-      face = ft.New_Memory_Face(buffer, 0);
+      face = {}
+      ft.New_Memory_Face(buffer, 0, face);
+      face = face.face
       charcode = ft.Get_First_Char(face, gindex)
 
       while gindex.gindex != 0


### PR DESCRIPTION
This includes PR #11 fixing and solves issues #11 #12 #15 #16 

Remove typo 'preview' as done by @rschiang in the PR #11 and also fixes the problem @rschiang himself stated in PR #11 of a further crash in atom editor after fixing the first bug.
As stated by @rschiang in PR #11 :
> Note: I've had another issue regarding a crash on calling ft.Get_First_Char in font-viewer.coffee, probably related to ericfreese/node-freetype2#10, so I haven't fully tested the PR yet.

The real problem was actually in the way the function New_Memory_Face was being called.